### PR TITLE
Make unaccent extension creation IF NOT EXISTS

### DIFF
--- a/crowdataapp/migrations/0026_add_strip_accents_function.py
+++ b/crowdataapp/migrations/0026_add_strip_accents_function.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        db.execute("CREATE EXTENSION unaccent");
+        db.execute("CREATE EXTENSION IF NOT EXISTS unaccent");
 
     def backwards(self, orm):
         pass


### PR DESCRIPTION
Hi,

We were taking a look at this project at NZ Herald.

Although I notice that crowdata/crowdata#18 crowdata/crowdata#19 refer to making the app database agnostic, we ran into the issue of migrations failing due to the `unaccent` extension already being created (which is a state one might get in following [these instructions](http://crowdata.readthedocs.org/en/latest/install.html) ).

This pull request just includes `IF NOT EXISTS` in the SQL string, as per the [Postgres docs](http://www.postgresql.org/docs/9.1/static/sql-createextension.html).

Hope that helps.

Thanks,

Caleb