### PR TITLE
Add browserid_info tag

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -11,6 +11,7 @@
 
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right">
+        {% browserid_info %}
         {% if user.is_authenticated %}
           <li class="dropdown">
             <a href=""reverse('user_profile', kwargs={'document_set':{{document_set}}, 'username':{{ user.username }} })"" class="dropdown-toggle username" data-toggle="dropdown">


### PR DESCRIPTION
Hi,

It appears that Browser ID is broken without the `{% browserid_info %}` tag. We found that adding this meant that we could log in with browser id.

We are still looking at an issue where logging in causes a 500 error with `DEBUG = False`.

There may be few more fixes we will send through as we find them, as we have just launched a production instance of Crowdata. Thanks for all your hard work releasing this project.


Caleb